### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-loader-partial
 ```
 
+### via NPM
+
+```bash
+$ npm install angular-translate-loader-partial
+```
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-loader-partial for specific versions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-loader-partial",
+  "version": "2.7.0",
+  "description": "angular-translate-loader-partial",
+  "main": "angular-translate-loader-partial.js",
+  "repository": {
+    "type": "git",
+    "url": "https://mchambaud@github.com/mchambaud/bower-angular-translate-loader-partial.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-loader-partial"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mchambaud/bower-angular-translate-loader-partial/issues"
+  },
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-loader-partial"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-loader-partial using NPM, enabling proper Browserification in the process.