### PR TITLE
Bugfix duplicate+parallel http requests per part

### DIFF
--- a/angular-translate-loader-partial.js
+++ b/angular-translate-loader-partial.js
@@ -76,7 +76,7 @@ function $translatePartialLoader() {
     if (!this.tables[lang]) {
       var self = this;
 
-      return $http(angular.extend({
+      this.tables[lang] = $http(angular.extend({
         method : 'GET',
         url: this.parseUrl(urlTemplate, lang)
       }, $httpOptions))
@@ -96,7 +96,8 @@ function $translatePartialLoader() {
             return $q.reject(self.name);
           }
         });
-
+      
+      return this.tables[lang];
     } else {
       return $q.when(this.tables[lang]);
     }


### PR DESCRIPTION
If the same part is requested multiple times in quick succession, then multiple parallel HTTP requests will be fired. The fix here, makes sure that there's only 1 HTTP request per part.